### PR TITLE
Revert "Update cairo to 2.10"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Get corelib
-        run: |
-          git clone https://github.com/starkware-libs/cairo
-          cd cairo
-          git checkout tags/v2.10.0
+        run: git clone https://github.com/starkware-libs/cairo
       - name: Run cargo test
         run: CORELIB_PATH="$(pwd)/cairo/corelib/src" cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,7 +63,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -86,7 +74,7 @@ checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -103,9 +91,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii-canvas"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
 dependencies = [
  "term",
 ]
@@ -124,18 +112,18 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -165,6 +153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5430e3be710b68d984d1391c854eb431a9d548640711faa54eecb1df93db91cc"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bstr"
 version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,9 +185,8 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff11aec4eb39d670efa69d8a6bda5803661578e9dc1be54ea948fe82fb39995"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -202,9 +198,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f704af3ba7499d63a695688d2f5b40109820f8ca38d78092a4aa4a64ec600d2"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -223,23 +218,21 @@ dependencies = [
  "rust-analyzer-salsa",
  "semver",
  "smol_str",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22020eb5184ceab861f249ca9fb5d17dbc1278fa88216663e1711da64fbe5a"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2322f996ea69a064a9cbad43b996e0352bf0218c6a27b8ff1423ad7942faaa29"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -247,28 +240,26 @@ dependencies = [
  "cairo-lang-parser",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "rust-analyzer-salsa",
  "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d4751c8b3835df963f9aed56a2dba2bb000af824809b2694c0876e3e9f7dee"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
  "cairo-lang-utils",
- "itertools 0.12.1",
+ "itertools 0.14.0",
 ]
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed621df2fcc246a81a71ace26fd1be34bbd19aeb60535c85d8e794710a2bef5e"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -276,9 +267,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0baa53250acf692f7214e997ec864a529d4aad7392f5a7798805659c195ac321"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -292,9 +282,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb00211393a7f992bcf33a17bbe189e1a9dbe247a2de04fe22a313d6b684f746"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -304,17 +293,16 @@ dependencies = [
  "cairo-lang-utils",
  "diffy",
  "ignore",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "rust-analyzer-salsa",
  "serde",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949be6b96044de47aaa2ecf99167a5ffa893de2ca21b1a869cb726cf90f37eec"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -326,28 +314,27 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "id-arena",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "num-bigint",
  "num-integer",
  "num-traits",
  "rust-analyzer-salsa",
- "smol_str",
 ]
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3dcc5e85867b0f715b30d62585ac750a4c7ab1f92813599ba17cc29e1d0a1d1"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
+ "cairo-lang-primitive-token",
  "cairo-lang-syntax",
  "cairo-lang-syntax-codegen",
  "cairo-lang-utils",
  "colored",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-traits",
  "rust-analyzer-salsa",
@@ -357,9 +344,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239cebcb9024d9e8eb26496055ffa325e5c2d868f798637fc69f25ac3b2ab5ca"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -369,7 +355,7 @@ dependencies = [
  "cairo-lang-utils",
  "indent",
  "indoc",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "rust-analyzer-salsa",
  "smol_str",
 ]
@@ -382,9 +368,8 @@ checksum = "123ac0ecadf31bacae77436d72b88fa9caef2b8e92c89ce63a125ae911a12fae"
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a98a058656493f4ef4b7fc51ed4fa46cc9b2834262815959746bf1696f1c50f"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -393,22 +378,20 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d111a3ffe3b463e79af5d6049a6e23fc5c7048e0bacea5ebd268107ded21012"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
  "serde",
- "thiserror",
+ "thiserror 2.0.11",
  "toml",
 ]
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5aedc89a6324b3dbdd6cf6827258c50035b7459cf818d88296d6d88c1a46cfd"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -422,7 +405,7 @@ dependencies = [
  "cairo-lang-utils",
  "id-arena",
  "indoc",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-traits",
  "rust-analyzer-salsa",
@@ -433,16 +416,15 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cfdac5d0a0be84e9247414b552905967e06feaef48633af4ca6e80240acb09"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
  "const-fnv1a-hash",
  "convert_case",
  "derivative",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "lalrpop",
  "lalrpop-util",
  "num-bigint",
@@ -455,46 +437,43 @@ dependencies = [
  "sha3",
  "smol_str",
  "starknet-types-core",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a923105c63704b7371f4ee92a17b3037c8be88f0c7021eb764d8f974a397ff5"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
  "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa8dc62dfa49f57dcdb092f551bcba42d0123f4d0f0763087b3b41142543ecf"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
  "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4526593827287b39af72c0d12698007a9fe693d8a8e9fc4e481885634e9c1601"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -506,7 +485,7 @@ dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "num-traits",
  "rust-analyzer-salsa",
  "serde",
@@ -516,9 +495,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4357f1cadb6a713c85560aacba92a794eac1f5c82021c0f28ce3a6810c4e334"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -528,18 +506,17 @@ dependencies = [
  "cairo-lang-sierra-type-size",
  "cairo-lang-utils",
  "indoc",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-traits",
  "starknet-types-core",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2963c5eea0778ba7f00e41916dc347b988ca73458edc3e460954e597484bc95"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -547,9 +524,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a18683311c0976fbff8ac237e1f0940707695efee77438b56c1604d1db9b5e"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -567,26 +543,25 @@ dependencies = [
  "const_format",
  "indent",
  "indoc",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "smol_str",
  "starknet-types-core",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467bf061c5a43844880d5566931d6d2866b714b4451c61072301ce40b484cda4"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
  "cairo-lang-sierra-to-casm",
  "cairo-lang-utils",
  "convert_case",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -595,14 +570,13 @@ dependencies = [
  "sha3",
  "smol_str",
  "starknet-types-core",
- "thiserror",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a45ff877463d52565f056a6e9f4689c3a2cea59fde66f9853f2f7ce9e44dc3"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -617,9 +591,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983e0ab5783bcb1ed70e7401c4c845762f7e033c0e213886f913b5dc875cbf08"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "genco",
  "xshell",
@@ -627,9 +600,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-plugin"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61348e6f51d666bf82ec8c536c9f5be22bd86f18a3b357ec3014223df01c81"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -645,7 +617,7 @@ dependencies = [
  "cairo-lang-syntax",
  "cairo-lang-utils",
  "indoc",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-traits",
  "serde",
@@ -654,9 +626,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a4f3e42fc818474f3767308159548ddbedc95a6fb857a04ebb95da725203ca"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-utils",
@@ -667,13 +638,12 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d000fa1b86f07587b9dcabdaed00878464944b96c8c1f3f5006e890a5a8870"
+version = "2.9.2"
+source = "git+https://github.com/starkware-libs/cairo?rev=3babe0518abc8e4fc72f519fb515d6c752138f78#3babe0518abc8e4fc72f519fb515d6c752138f78"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "indexmap 2.7.1",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-traits",
  "schemars",
@@ -733,6 +703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,12 +756,11 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "lazy_static",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -798,7 +773,7 @@ dependencies = [
  "libc",
  "once_cell",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -829,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -869,12 +844,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -915,9 +884,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "diffy"
-version = "0.3.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e616e59155c92257e84970156f506287853355f58cd4a6eb167385722c32b790"
+checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
 dependencies = [
  "nu-ansi-term",
 ]
@@ -930,27 +899,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -988,15 +936,21 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "funty"
@@ -1037,17 +991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "globset"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,20 +1021,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
- "serde",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heck"
@@ -1104,6 +1042,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "id-arena"
@@ -1212,27 +1159,18 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1264,33 +1202,34 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.20.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+checksum = "7047a26de42016abf8f181b46b398aef0b77ad46711df41847f6ed869a2a1d5b"
 dependencies = [
  "ascii-canvas",
  "bit-set",
  "ena",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "lalrpop-util",
  "petgraph",
  "pico-args",
  "regex",
  "regex-syntax",
+ "sha3",
  "string_cache",
  "term",
- "tiny-keccak",
  "unicode-xid",
  "walkdir",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+checksum = "e8d05b3fe34b8bd562c338db725dfa9beb9451a48f65f129ccb9538b48d2c93b"
 dependencies = [
  "regex-automata",
+ "rustversion",
 ]
 
 [[package]]
@@ -1326,16 +1265,6 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -1408,12 +1337,11 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1471,12 +1399,6 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
@@ -1537,9 +1459,9 @@ checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap 2.7.1",
@@ -1686,17 +1608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,7 +1731,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1973,10 +1884,11 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smol_str"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
 dependencies = [
+ "borsh",
  "serde",
 ]
 
@@ -2061,13 +1973,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "term"
-version = "0.7.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+checksum = "a3bb6001afcea98122260987f8b7b5da969ecad46dbf0b5453702f776b491a41"
 dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
+ "home",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2109,7 +2020,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -2124,12 +2044,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
+name = "thiserror-impl"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
- "crunchy",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2220,7 +2142,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c878a167baa8afd137494101a688ef8c67125089ff2249284bd2b5f9bfedb815"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2274,12 +2196,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -2349,35 +2265,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2499,23 +2402,3 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,15 @@ license-file = "LICENSE"
 [workspace.dependencies]
 annotate-snippets = "0.11.5"
 anyhow = "1.0.95"
-cairo-lang-compiler = "2.10"
-cairo-lang-defs = "2.10"
-cairo-lang-diagnostics = "2.10"
-cairo-lang-filesystem = "2.10"
-cairo-lang-semantic = "2.10"
-cairo-lang-starknet = "2.10"
-cairo-lang-syntax = "2.10"
-cairo-lang-test-plugin = "2.10"
-cairo-lang-utils = "2.10"
+cairo-lang-compiler = "*"
+cairo-lang-defs = "*"
+cairo-lang-diagnostics = "*"
+cairo-lang-filesystem = "*"
+cairo-lang-semantic = "*"
+cairo-lang-starknet = "*"
+cairo-lang-syntax = "*"
+cairo-lang-test-plugin = "*"
+cairo-lang-utils = "*"
 clap = { version = "4.5.27", features = ["derive"]}
 ctor = "0.2.9"
 if_chain = "1.0.2"
@@ -47,7 +47,7 @@ itertools = "0.13.0"
 log = "0.4.25"
 num-bigint = "0.4.6"
 pretty_assertions = "1.4.1"
-smol_str = { version = "0.2.0", features = ["serde"] }
+smol_str = { version = "0.3.2", features = ["serde"] }
 test-case = "3.0"
 
 # Here we specify real dependency specifications for Cairo crates *if* currently we want to use
@@ -56,3 +56,30 @@ test-case = "3.0"
 # on some of them directly.
 # This ensures no duplicate instances of Cairo crates are pulled in by mistake.
 [patch.crates-io]
+cairo-lang-casm = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-debug = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-eq-solver = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-proc-macros = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-project = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-sierra-ap-change = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-sierra-gas = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-sierra-to-casm = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-sierra-type-size = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-starknet-classes = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-syntax-codegen = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-test-plugin = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-test-utils = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }
+cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo", rev = "3babe0518abc8e4fc72f519fb515d6c752138f78" }

--- a/crates/cairo-lint-core/src/lints/bool_comparison.rs
+++ b/crates/cairo-lint-core/src/lints/bool_comparison.rs
@@ -61,7 +61,7 @@ fn check_single_bool_comparison(
     // Check if the function call is the bool partial eq function (==).
     if !function_call_expr
         .function
-        .full_name(db)
+        .full_path(db)
         .contains("core::BoolPartialEq::")
     {
         return;

--- a/crates/cairo-lint-core/src/lints/int_op_one.rs
+++ b/crates/cairo-lint-core/src/lints/int_op_one.rs
@@ -129,7 +129,7 @@ fn check_single_int_op_one(
     diagnostics: &mut Vec<PluginDiagnostic>,
 ) {
     // Check if the function call is the bool greater or equal (>=) or lower or equal (<=).
-    let full_name = function_call_expr.function.full_name(db);
+    let full_name = function_call_expr.function.full_path(db);
     if !full_name.contains("core::integer::")
         || (!full_name.contains("PartialOrd::ge") && !full_name.contains("PartialOrd::le"))
     {
@@ -142,7 +142,7 @@ fn check_single_int_op_one(
     // x >= y + 1
     if check_is_variable(lhs, arenas)
         && check_is_add_or_sub_one(db, rhs, arenas, "::add")
-        && function_call_expr.function.full_name(db).contains("::ge")
+        && function_call_expr.function.full_path(db).contains("::ge")
     {
         diagnostics.push(PluginDiagnostic {
             stable_ptr: function_call_expr.stable_ptr.untyped(),
@@ -154,7 +154,7 @@ fn check_single_int_op_one(
     // x - 1 >= y
     if check_is_add_or_sub_one(db, lhs, arenas, "::sub")
         && check_is_variable(rhs, arenas)
-        && function_call_expr.function.full_name(db).contains("::ge")
+        && function_call_expr.function.full_path(db).contains("::ge")
     {
         diagnostics.push(PluginDiagnostic {
             stable_ptr: function_call_expr.stable_ptr.untyped(),
@@ -166,7 +166,7 @@ fn check_single_int_op_one(
     // x + 1 <= y
     if check_is_add_or_sub_one(db, lhs, arenas, "::add")
         && check_is_variable(rhs, arenas)
-        && function_call_expr.function.full_name(db).contains("::le")
+        && function_call_expr.function.full_path(db).contains("::le")
     {
         diagnostics.push(PluginDiagnostic {
             stable_ptr: function_call_expr.stable_ptr.untyped(),
@@ -178,7 +178,7 @@ fn check_single_int_op_one(
     // x <= y - 1
     if check_is_variable(lhs, arenas)
         && check_is_add_or_sub_one(db, rhs, arenas, "::sub")
-        && function_call_expr.function.full_name(db).contains("::le")
+        && function_call_expr.function.full_path(db).contains("::le")
     {
         diagnostics.push(PluginDiagnostic {
             stable_ptr: function_call_expr.stable_ptr.untyped(),
@@ -210,7 +210,7 @@ fn check_is_add_or_sub_one(
     };
 
     // Check is addition or substraction
-    let full_name = func_call.function.full_name(db);
+    let full_name = func_call.function.full_path(db);
     if !full_name.contains("core::integer::") && !full_name.contains(operation)
         || func_call.args.len() != 2
     {

--- a/crates/cairo-lint-core/src/lints/manual/helpers.rs
+++ b/crates/cairo-lint-core/src/lints/manual/helpers.rs
@@ -22,7 +22,7 @@ pub fn is_expected_function(expr: &Expr, db: &dyn SemanticGroup, func_name: &str
     let Expr::FunctionCall(func_call) = expr else {
         return false;
     };
-    func_call.function.full_name(db).as_str() == func_name
+    func_call.function.full_path(db).as_str() == func_name
 }
 
 /// Checks if the inner_pattern in the input `Pattern::Enum` matches the given argument name.

--- a/crates/cairo-lint-core/src/lints/manual/mod.rs
+++ b/crates/cairo-lint-core/src/lints/manual/mod.rs
@@ -176,7 +176,7 @@ fn check_syntax_ok_arm(
         }
         ManualLint::ManualExpectErr => {
             if let Expr::FunctionCall(func_call) = &arenas.exprs[arm.expression] {
-                let func_name = func_call.function.full_name(db);
+                let func_name = func_call.function.full_path(db);
                 func_name == PANIC_WITH_FELT252
             } else {
                 false
@@ -199,7 +199,7 @@ fn check_syntax_none_arm(
         ManualLint::ManualIsNone => is_expected_variant(arm_expression, arenas, db, TRUE),
         ManualLint::ManualOptExpect => {
             if let Expr::FunctionCall(func_call) = &arenas.exprs[*arm_expression] {
-                let func_name = func_call.function.full_name(db);
+                let func_name = func_call.function.full_path(db);
                 func_name == PANIC_WITH_FELT252
             } else {
                 false
@@ -232,7 +232,7 @@ fn check_syntax_err_arm(
         ),
         ManualLint::ManualResExpect => {
             if let Expr::FunctionCall(func_call) = &arenas.exprs[arm.expression] {
-                let func_name = func_call.function.full_name(db);
+                let func_name = func_call.function.full_path(db);
                 func_name == PANIC_WITH_FELT252
             } else {
                 false

--- a/crates/cairo-lint-core/src/lints/panic.rs
+++ b/crates/cairo-lint-core/src/lints/panic.rs
@@ -56,7 +56,7 @@ fn check_single_panic_usage(
         .clone();
 
     // If the function is not the panic function from the corelib return
-    if function_call_expr.function.full_name(db) != PANIC {
+    if function_call_expr.function.full_path(db) != PANIC {
         return;
     }
 


### PR DESCRIPTION
Reverts software-mansion/cairo-lint#196

We have to do this because it breaks nightly builds of LS and Scarb.