### PR TITLE
Fix int_op_one rule

### DIFF
--- a/crates/cairo-lint-core/src/lints/int_op_one.rs
+++ b/crates/cairo-lint-core/src/lints/int_op_one.rs
@@ -231,13 +231,13 @@ fn check_is_add_or_sub_one(
     if_chain! {
         if let ExprFunctionCallArg::Value(v) = rhs;
         if let Expr::Literal(ref litteral_expr) = arenas.exprs[*v];
-        if litteral_expr.value != 1.into();
+        if litteral_expr.value == 1.into();
         then {
-            return false;
+            return true;
         }
     }
 
-    true
+    false
 }
 
 /// Rewrites a manual implementation of int ge plus one x >= y + 1

--- a/crates/cairo-lint-core/tests/int_operations/mod.rs
+++ b/crates/cairo-lint-core/tests/int_operations/mod.rs
@@ -49,6 +49,17 @@ fn main() {
 }
 "#;
 
+const INT_LE_PLUS_ONE_NOT: &str = r#"
+fn f() -> u32 {
+    2
+}
+fn main() {
+    let x: u32 = 1;
+    let y: u32 = 1;
+    if x + f() <= y {}
+}
+"#;
+
 const INT_LT_PLUS_ONE: &str = r#"
 fn main() {
     let x: u32 = 1;
@@ -181,6 +192,11 @@ fn int_le_plus_one_diagnostics() {
       |        ----------
       |
     ");
+}
+
+#[test]
+fn int_le_plus_one_not_diagnostics() {
+    test_lint_diagnostics!(INT_LE_PLUS_ONE_NOT, @r"");
 }
 
 #[test]


### PR DESCRIPTION
The following code 
```rust
fn f() -> u32 {
    2
}
fn main() {
    let x: u32 = 1;
    let y: u32 = 1;
    if x + f() <= y {}
}
```

is replaced by the linter with 
```rust
fn f() -> u32 {
    2
}
fn main() {
    let x: u32 = 1;
    let y: u32 = 1;
    if x < y {} 
}
```

where the call to `f()` is incorrectly removed.