### PR TITLE
Add separate plugin for LS without metadata validation

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -23,6 +23,14 @@ pub fn cairo_lint_plugin_suite(tool_metadata: CairoLintToolMetadata) -> Result<P
     Ok(suite)
 }
 
+pub fn cairo_lint_plugin_suite_without_metadata_validation(
+    tool_metadata: CairoLintToolMetadata,
+) -> Result<PluginSuite> {
+    let mut suite = PluginSuite::default();
+    suite.add_analyzer_plugin_ex(Arc::new(CairoLint::new(false, tool_metadata)));
+    Ok(suite)
+}
+
 pub fn cairo_lint_allow_plugin_suite() -> PluginSuite {
     let mut suite = PluginSuite::default();
     suite.add_analyzer_plugin::<CairoLintAllow>();


### PR DESCRIPTION
We want to have a separate plugin creation entry point for LS, as it wants to create a plugin even if the metadata provided by user is not valid