### PR TITLE
Add `.rs.pending-snap` files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 .idea/
 .DS_Store
+*.rs.pending-snap


### PR DESCRIPTION
Insta generates `.rs.pending-snap` during testing if the snapshot differs from current return value. We dont want to track those files