### PR TITLE
Add getters for `CairoLint` attributes

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -53,6 +53,14 @@ impl CairoLint {
             tool_metadata,
         }
     }
+
+    pub fn include_compiler_generated_files(&self) -> bool {
+        self.include_compiler_generated_files
+    }
+
+    pub fn tool_metadata(&self) -> &CairoLintToolMetadata {
+        &self.tool_metadata
+    }
 }
 
 impl AnalyzerPlugin for CairoLint {


### PR DESCRIPTION
## Changes
* `CairoLint` has two methods: `tool_metadata` and `include_compiler_generated_files` corresponding to its fields
* They are used by LS to get the configuration of the linter from plugin in runtime