### PR TITLE
Format fixed files in public API

### DIFF
--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -91,8 +91,8 @@ pub fn get_fixes_without_resolving_overlapping(
             if let Some(import_paths) = import_addition_paths {
                 let imports_suggestion = import_paths
                     .iter()
-                    .map(|import_path| format!("use {};", import_path))
-                    .join("\n");
+                    .map(|import_path| format!("use {};\n", import_path))
+                    .join("");
                 fixes
                     .entry(location.file_id)
                     .or_insert_with(Vec::new)


### PR DESCRIPTION
Resolves #340 
Tested with scarb locally. It formats the fixed file (as well as removes duplicated imports)