### PR TITLE
Support reversed `match` arms in `manual_*` lints

### DIFF
--- a/src/lints/manual/manual_expect_err.rs
+++ b/src/lints/manual/manual_expect_err.rs
@@ -10,13 +10,13 @@ use cairo_lang_syntax::node::{
 use crate::{
     context::CairoLintKind,
     fixer::InternalFix,
+    lints::manual::helpers::{MatchOnOption, MatchOnResult, extract_err},
     queries::{get_all_function_bodies, get_all_if_expressions, get_all_match_expressions},
 };
 use crate::{
     context::Lint,
     lints::manual::{
-        ManualLint, check_manual, check_manual_if,
-        helpers::{expr_if_get_var_name_and_err, expr_match_get_var_name_and_err},
+        ManualLint, check_manual, check_manual_if, helpers::expr_if_get_var_name_and_err,
     },
 };
 use salsa::Database;
@@ -118,11 +118,18 @@ pub fn fix_manual_expect_err<'db>(
     let fix = match node.kind(db) {
         SyntaxKind::ExprMatch => {
             let expr_match = ExprMatch::from_syntax_node(db, node);
+            let target_expr = expr_match.expr(db).as_syntax_node().get_text(db).trim_end();
 
-            let (option_var_name, none_arm_err) =
-                expr_match_get_var_name_and_err(expr_match, db, 0);
+            let arm = MatchOnOption::try_new(db, &expr_match)
+                .map(|match_on_option| match_on_option.some_arm)
+                .or_else(|| {
+                    MatchOnResult::try_new(db, &expr_match)
+                        .map(|match_on_result| match_on_result.ok_arm)
+                })
+                .expect("Expected a match expression on either Option or Result");
 
-            format!("{}.expect_err({none_arm_err})", option_var_name.trim_end())
+            let err = extract_err(db, &arm);
+            format!("{target_expr}.expect_err({err})")
         }
         SyntaxKind::ExprIf => {
             let expr_if = ExprIf::from_syntax_node(db, node);

--- a/src/lints/manual/manual_ok_or.rs
+++ b/src/lints/manual/manual_ok_or.rs
@@ -10,13 +10,13 @@ use cairo_lang_syntax::node::{
 use crate::{
     context::CairoLintKind,
     fixer::InternalFix,
+    lints::manual::helpers::{MatchOnOption, MatchOnResult, extract_err},
     queries::{get_all_function_bodies, get_all_if_expressions, get_all_match_expressions},
 };
 use crate::{
     context::Lint,
     lints::manual::{
-        ManualLint, check_manual, check_manual_if,
-        helpers::{expr_if_get_var_name_and_err, expr_match_get_var_name_and_err},
+        ManualLint, check_manual, check_manual_if, helpers::expr_if_get_var_name_and_err,
     },
 };
 use salsa::Database;
@@ -116,11 +116,18 @@ pub fn fix_manual_ok_or<'db>(
     let fix = match node.kind(db) {
         SyntaxKind::ExprMatch => {
             let expr_match = ExprMatch::from_syntax_node(db, node);
+            let target_expr = expr_match.expr(db).as_syntax_node().get_text(db).trim_end();
 
-            let (option_var_name, none_arm_err) =
-                expr_match_get_var_name_and_err(expr_match, db, 1);
+            let arm = MatchOnOption::try_new(db, &expr_match)
+                .map(|match_on_option| match_on_option.none_arm)
+                .or_else(|| {
+                    MatchOnResult::try_new(db, &expr_match)
+                        .map(|match_on_result| match_on_result.err_arm)
+                })
+                .expect("Expected a match expression on either Option or Result");
 
-            format!("{}.ok_or({none_arm_err})", option_var_name.trim_end())
+            let err = extract_err(db, &arm);
+            format!("{target_expr}.ok_or({err})")
         }
         SyntaxKind::ExprIf => {
             let expr_if = ExprIf::from_syntax_node(db, node);

--- a/src/lints/manual/mod.rs
+++ b/src/lints/manual/mod.rs
@@ -116,6 +116,21 @@ pub fn check_manual<'db>(
                 manual_lint,
             )
         }
+        (NONE, SOME) => {
+            check_syntax_none_arm(
+                first_expr,
+                &arenas.patterns[first_arm.patterns[0]],
+                db,
+                arenas,
+                manual_lint,
+            ) && check_syntax_some_arm(
+                second_expr,
+                &arenas.patterns[second_arm.patterns[0]],
+                db,
+                arenas,
+                manual_lint,
+            )
+        }
         (OK, ERR) => {
             check_syntax_ok_arm(
                 first_expr,
@@ -124,6 +139,21 @@ pub fn check_manual<'db>(
                 arenas,
                 manual_lint,
             ) && check_syntax_err_arm(
+                second_expr,
+                &arenas.patterns[second_arm.patterns[0]],
+                db,
+                arenas,
+                manual_lint,
+            )
+        }
+        (ERR, OK) => {
+            check_syntax_err_arm(
+                first_expr,
+                &arenas.patterns[first_arm.patterns[0]],
+                db,
+                arenas,
+                manual_lint,
+            ) && check_syntax_ok_arm(
                 second_expr,
                 &arenas.patterns[second_arm.patterns[0]],
                 db,

--- a/tests/manual/manual_err.rs
+++ b/tests/manual/manual_err.rs
@@ -67,7 +67,7 @@ fn main() {
     let _foo = match foo {
         Result::Ok(_) => {
             // let _a = 5;
-        
+
             Option::None
         },
         Result::Err(x) => {
@@ -89,6 +89,16 @@ fn main() {
         Result::Err(x) => {
             Option::Some(x)
         },
+    };
+}
+"#;
+
+const TEST_MATCH_WITH_REVERSED_ARMS: &str = r#"
+fn main() {
+    let a: Result<usize> = Result::Err('error');
+    let _ = match a {
+        Result::Err(err) => Option::Some(err),
+        Result::Ok(_) => Option::None,
     };
 }
 "#;
@@ -249,4 +259,27 @@ fn test_basic_err_block_with_more_statements_fixer() {
         };
     }
     ")
+}
+
+#[test]
+fn match_with_reversed_arms_diagnostics() {
+    test_lint_diagnostics!(TEST_MATCH_WITH_REVERSED_ARMS, @r"
+    Plugin diagnostic: Manual match for `err` detected. Consider using `err()` instead
+     --> lib.cairo:4:13-7:5
+          let _ = match a {
+     _____________^
+    | ...
+    |     };
+    |_____^
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_fixer() {
+    test_lint_fixer!(TEST_MATCH_WITH_REVERSED_ARMS, @r"
+    fn main() {
+        let a: Result<usize> = Result::Err('error');
+        let _ = a.err();
+    }
+    ");
 }

--- a/tests/manual/manual_expect.rs
+++ b/tests/manual/manual_expect.rs
@@ -191,6 +191,26 @@ fn main() {
 }
 "#;
 
+const TEST_MATCH_WITH_REVERSED_ARMS_OPTION: &str = r#"
+fn main() {
+    let a: Option<usize> = Option::None;
+    let _ = match a {
+        Option::None => core::panic_with_felt252('other-error'),
+        Option::Some(v) => v,
+    };
+}
+"#;
+
+const TEST_MATCH_WITH_REVERSED_ARMS_RESULT: &str = r#"
+fn main() {
+    let a: Result<usize> = Result::Err('error');
+    let _ = match a {
+        Result::Err(_) => core::panic_with_felt252('other-error'),
+        Result::Ok(v) => v,
+    };
+}
+"#;
+
 #[test]
 fn test_core_panic_with_felt252_diagnostics() {
     test_lint_diagnostics!(TEST_CORE_PANIC_WITH_FELT252, @r"
@@ -525,6 +545,52 @@ fn test_core_panic_with_felt252_block_fixer() {
         let foo: Option<i32> = Option::None;
         // This is just a variable.
         let _foo = foo.expect('err');
+    }
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_option_diagnostics() {
+    test_lint_diagnostics!(TEST_MATCH_WITH_REVERSED_ARMS_OPTION, @r"
+    Plugin diagnostic: Manual match for expect detected. Consider using `expect()` instead
+     --> lib.cairo:4:13-7:5
+          let _ = match a {
+     _____________^
+    | ...
+    |     };
+    |_____^
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_option_fixer() {
+    test_lint_fixer!(TEST_MATCH_WITH_REVERSED_ARMS_OPTION, @r"
+    fn main() {
+        let a: Option<usize> = Option::None;
+        let _ = a.expect('other-error');
+    }
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_result_diagnostics() {
+    test_lint_diagnostics!(TEST_MATCH_WITH_REVERSED_ARMS_RESULT, @r"
+    Plugin diagnostic: Manual match for expect detected. Consider using `expect()` instead
+     --> lib.cairo:4:13-7:5
+          let _ = match a {
+     _____________^
+    | ...
+    |     };
+    |_____^
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_result_fixer() {
+    test_lint_fixer!(TEST_MATCH_WITH_REVERSED_ARMS_RESULT, @r"
+    fn main() {
+        let a: Result<usize> = Result::Err('error');
+        let _ = a.expect('other-error');
     }
     ");
 }

--- a/tests/manual/manual_is_err.rs
+++ b/tests/manual/manual_is_err.rs
@@ -80,6 +80,16 @@ fn main() {
 }
 "#;
 
+const MATCH_WITH_REVERSED_ARMS: &str = r#"
+fn main() {
+    let a: Result<usize, ()> = Result::Err(());
+    let _ = match a {
+        Result::Err(_) => true,
+        Result::Ok(_) => false,
+    };
+}
+"#;
+
 #[test]
 fn test_basic_is_err_diagnostics() {
     test_lint_diagnostics!(TEST_BASIC_IS_ERR, @r"
@@ -224,6 +234,29 @@ fn test_basic_is_err_block_fixer() {
         let res_val: Result<i32> = Result::Err('err');
         // This is just a variable.
         let _a = res_val.is_err();
+    }
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_diagnostics() {
+    test_lint_diagnostics!(MATCH_WITH_REVERSED_ARMS, @r"
+    Plugin diagnostic: Manual match for `is_err` detected. Consider using `is_err()` instead
+     --> lib.cairo:4:13-7:5
+          let _ = match a {
+     _____________^
+    | ...
+    |     };
+    |_____^
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_fixer() {
+    test_lint_fixer!(MATCH_WITH_REVERSED_ARMS, @r"
+    fn main() {
+        let a: Result<usize, ()> = Result::Err(());
+        let _ = a.is_err();
     }
     ");
 }

--- a/tests/manual/manual_is_none.rs
+++ b/tests/manual/manual_is_none.rs
@@ -106,6 +106,16 @@ fn main() {
 }
 "#;
 
+const MATCH_WITH_REVERSED_ARMS: &str = r#"
+fn main() {
+    let a: Option<usize> = Option::None;
+    let _ = match a {
+        Option::None => true,
+        Option::Some(_) => false,
+    };
+}
+"#;
+
 #[test]
 fn test_basic_is_none_diagnostics() {
     test_lint_diagnostics!(TEST_BASIC_IS_NONE, @r"
@@ -293,6 +303,29 @@ fn test_basic_is_none_block_fixer() {
         let foo: Option<i32> = Option::None;
         // This is just a variable.
         let _foo = foo.is_none();
+    }
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_diagnostics() {
+    test_lint_diagnostics!(MATCH_WITH_REVERSED_ARMS, @r"
+    Plugin diagnostic: Manual match for `is_none` detected. Consider using `is_none()` instead
+     --> lib.cairo:4:13-7:5
+          let _ = match a {
+     _____________^
+    | ...
+    |     };
+    |_____^
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_fixer() {
+    test_lint_fixer!(MATCH_WITH_REVERSED_ARMS, @r"
+    fn main() {
+        let a: Option<usize> = Option::None;
+        let _ = a.is_none();
     }
     ");
 }

--- a/tests/manual/manual_is_ok.rs
+++ b/tests/manual/manual_is_ok.rs
@@ -77,6 +77,16 @@ fn main() {
 }
 "#;
 
+const MATCH_WITH_REVERSED_ARMS: &str = r#"
+fn main() {
+    let a: Result<usize, ()> = Result::Err(());
+    let _ = match a {
+        Result::Err(_) => false,
+        Result::Ok(_) => true,
+    };
+}
+"#;
+
 #[test]
 fn test_basic_is_ok_diagnostics() {
     test_lint_diagnostics!(TEST_BASIC_IS_OK, @r"
@@ -218,6 +228,29 @@ fn test_basic_is_ok_block_fixer() {
         let res_val: Result<i32> = Result::Err('err');
         // This is just a variable.
         let _a = res_val.is_ok();
+    }
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_diagnostics() {
+    test_lint_diagnostics!(MATCH_WITH_REVERSED_ARMS, @r"
+    Plugin diagnostic: Manual match for `is_ok` detected. Consider using `is_ok()` instead
+     --> lib.cairo:4:13-7:5
+          let _ = match a {
+     _____________^
+    | ...
+    |     };
+    |_____^
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_fixer() {
+    test_lint_fixer!(MATCH_WITH_REVERSED_ARMS, @r"
+    fn main() {
+        let a: Result<usize, ()> = Result::Err(());
+        let _ = a.is_ok();
     }
     ");
 }

--- a/tests/manual/manual_is_some.rs
+++ b/tests/manual/manual_is_some.rs
@@ -106,6 +106,16 @@ fn main() {
 }
 "#;
 
+const MATCH_WITH_REVERSED_ARMS: &str = r#"
+fn main() {
+    let a: Option<usize> = Option::None;
+    let _ = match a {
+        Option::None => false,
+        Option::Some(_) => true,
+    };
+}
+"#;
+
 #[test]
 fn test_basic_is_some_diagnostics() {
     test_lint_diagnostics!(TEST_BASIC_IS_SOME, @r"
@@ -293,6 +303,29 @@ fn test_basic_is_some_block_fixer() {
         let foo: Option<i32> = Option::None;
         // This is just a variable.
         let _foo = foo.is_some();
+    }
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_diagnostics() {
+    test_lint_diagnostics!(MATCH_WITH_REVERSED_ARMS, @r"
+    Plugin diagnostic: Manual match for `is_some` detected. Consider using `is_some()` instead
+     --> lib.cairo:4:13-7:5
+          let _ = match a {
+     _____________^
+    | ...
+    |     };
+    |_____^
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_fixer() {
+    test_lint_fixer!(MATCH_WITH_REVERSED_ARMS, @r"
+    fn main() {
+        let a: Option<usize> = Option::None;
+        let _ = a.is_some();
     }
     ");
 }

--- a/tests/manual/manual_ok.rs
+++ b/tests/manual/manual_ok.rs
@@ -76,6 +76,16 @@ fn main() {
 }
 "#;
 
+const MATCH_WITH_REVERSED_ARMS: &str = r#"
+fn main() {
+    let a: Result<usize, ()> = Result::Err(());
+    let _ = match a {
+        Result::Err(_) => Option::None,
+        Result::Ok(v) => Option::Some(v),
+    };
+}
+"#;
+
 #[test]
 fn test_basic_ok_diagnostics() {
     test_lint_diagnostics!(TEST_BASIC_OK, @r"
@@ -209,6 +219,29 @@ fn test_basic_ok_block_fixer() {
         let res_val: Result<i32> = Result::Err('err');
         // This is just a variable.
         let _a = res_val.ok();
+    }
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_diagnostics() {
+    test_lint_diagnostics!(MATCH_WITH_REVERSED_ARMS, @r"
+    Plugin diagnostic: Manual match for `ok` detected. Consider using `ok()` instead
+     --> lib.cairo:4:13-7:5
+          let _ = match a {
+     _____________^
+    | ...
+    |     };
+    |_____^
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_fixer() {
+    test_lint_fixer!(MATCH_WITH_REVERSED_ARMS, @r"
+    fn main() {
+        let a: Result<usize, ()> = Result::Err(());
+        let _ = a.ok();
     }
     ");
 }

--- a/tests/manual/manual_ok_or.rs
+++ b/tests/manual/manual_ok_or.rs
@@ -161,6 +161,16 @@ fn main() {
 }
 "#;
 
+const MATCH_WITH_REVERSED_ARMS: &str = r#"
+fn main() {
+    let a: Option<usize> = Option::None;
+    let _ = match a {
+        Option::None => Result::Err('error'),
+        Option::Some(v) => Result::Ok(v),
+    };
+}
+"#;
+
 #[test]
 fn test_error_str_diagnostics() {
     test_lint_diagnostics!(TEST_ERROR_STR, @r"
@@ -442,4 +452,27 @@ fn test_error_str_block_more_statements_fixer() {
         };
     }
     ")
+}
+
+#[test]
+fn match_with_reversed_arms_diagnostics() {
+    test_lint_diagnostics!(MATCH_WITH_REVERSED_ARMS, @r"
+    Plugin diagnostic: Manual match for Option<T> detected. Consider using ok_or instead
+     --> lib.cairo:4:13-7:5
+          let _ = match a {
+     _____________^
+    | ...
+    |     };
+    |_____^
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_fixer() {
+    test_lint_fixer!(MATCH_WITH_REVERSED_ARMS, @r"
+    fn main() {
+        let a: Option<usize> = Option::None;
+        let _ = a.ok_or('error');
+    }
+    ");
 }

--- a/tests/manual/manual_unwrap_or_default.rs
+++ b/tests/manual/manual_unwrap_or_default.rs
@@ -190,7 +190,7 @@ fn main() {
     // testing with comments ok arm
     v
   } else {
-    // testing with comments err arm 
+    // testing with comments err arm
     Default::default()
   };
 }
@@ -385,7 +385,7 @@ fn main() {
       // Testing with comments
       v
     },
-    Option::None => { // comment after { 
+    Option::None => { // comment after {
       // Testing with comments
       [0; 5]
       // comment before }
@@ -483,10 +483,10 @@ fn main() {
     // Some before
     let _z = if let Option::Some(v) = a {
         v
-    } else { // comment after { 
+    } else { // comment after {
         // Some comment
         0 // Comment after value
-        // comment before } 
+        // comment before }
     };
 }
 "#;
@@ -498,8 +498,28 @@ fn main() {
     let _x = match a {
         Result::Ok(v) => v,
         Result::Err(_) => // comment after =>
-            // Different comment 
-            0 
+            // Different comment
+            0
+    };
+}
+"#;
+
+const MATCH_WITH_REVERSED_ARMS_OPTION: &str = r#"
+fn main() {
+    let a: Option<usize> = Option::None;
+    let _ = match a {
+        Option::None => 0,
+        Option::Some(v) => v,
+    };
+}
+"#;
+
+const MATCH_WITH_REVERSED_ARMS_RESULT: &str = r#"
+fn main() {
+    let a: Result<usize, ()> = Result::Err(());
+    let _ = match a {
+        Result::Err(_) => 0,
+        Result::Ok(v) => v,
     };
 }
 "#;
@@ -1506,6 +1526,52 @@ fn manual_unwrap_or_default_result_for_match_with_comment_after_arrow_fixer() {
         // comment after =>
         // Different comment
         let _x = a.unwrap_or_default();
+    }
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_option_diagnostics() {
+    test_lint_diagnostics!(MATCH_WITH_REVERSED_ARMS_OPTION, @r"
+    Plugin diagnostic: This can be done in one call with `.unwrap_or_default()`
+     --> lib.cairo:4:13-7:5
+          let _ = match a {
+     _____________^
+    | ...
+    |     };
+    |_____^
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_option_fixer() {
+    test_lint_fixer!(MATCH_WITH_REVERSED_ARMS_OPTION, @r"
+    fn main() {
+        let a: Option<usize> = Option::None;
+        let _ = a.unwrap_or_default();
+    }
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_result_diagnostics() {
+    test_lint_diagnostics!(MATCH_WITH_REVERSED_ARMS_RESULT, @r"
+    Plugin diagnostic: This can be done in one call with `.unwrap_or_default()`
+     --> lib.cairo:4:13-7:5
+          let _ = match a {
+     _____________^
+    | ...
+    |     };
+    |_____^
+    ");
+}
+
+#[test]
+fn match_with_reversed_arms_result_fixer() {
+    test_lint_fixer!(MATCH_WITH_REVERSED_ARMS_RESULT, @r"
+    fn main() {
+        let a: Result<usize, ()> = Result::Err(());
+        let _ = a.unwrap_or_default();
     }
     ");
 }


### PR DESCRIPTION
Closes #485 